### PR TITLE
#12 Fixed wrong return types

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -89,7 +89,7 @@ class Currency extends Intl
      *
      * @param string|int|float $value
      * @param string $currencyCode
-     * @return int|float
+     * @return string|false
      */
     public function parse($value, $currencyCode)
     {

--- a/src/Number.php
+++ b/src/Number.php
@@ -55,7 +55,7 @@ class Number extends Intl
      * Parse a localized number into native PHP format.
      *
      * @param string|int|float $value
-     * @return int|float
+     * @return string|false
      */
     public function parse($value)
     {


### PR DESCRIPTION
Affected methods
* Number::parse()
* Currency::parse()