### PR TITLE
Initial update for commerceguys/intl v1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.5.0",
         "illuminate/container": ">=5.0,<5.7",
-        "commerceguys/intl": ">=0.7.3,<=0.7.5",
+        "commerceguys/intl": "^1.0.0",
+        "commerceguys/addressing": "^1.0.0",
         "jenssegers/date": "^3.2"
     },
     "require-dev": {

--- a/src/Country.php
+++ b/src/Country.php
@@ -1,19 +1,19 @@
 <?php namespace Propaganistas\LaravelIntl;
 
-use CommerceGuys\Intl\Country\CountryRepository;
+use CommerceGuys\Addressing\Country\CountryRepository;
 use Propaganistas\LaravelIntl\Base\Intl;
 
 class Country extends Intl
 {
     /**
-     * @var \CommerceGuys\Intl\Country\CountryRepository
+     * @var \CommerceGuys\Addressing\Country\CountryRepository
      */
     protected $data;
 
     /**
      * Country constructor.
      *
-     * @param \CommerceGuys\Intl\Country\CountryRepository $data
+     * @param \CommerceGuys\Addressing\Country\CountryRepository $data
      */
     public function __construct(CountryRepository $data)
     {

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -1,7 +1,7 @@
 <?php namespace Propaganistas\LaravelIntl;
 
 use CommerceGuys\Intl\Currency\CurrencyRepository;
-use CommerceGuys\Intl\Formatter\NumberFormatter;
+use CommerceGuys\Intl\Formatter\CurrencyFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use Propaganistas\LaravelIntl\Base\Intl;
 
@@ -60,11 +60,9 @@ class Currency extends Intl
      */
     public function format($value, $currencyCode)
     {
-        $currency = $this->get($currencyCode);
-        $format = $this->formatData->get(null);
-        $formatter = new NumberFormatter($format, NumberFormatter::CURRENCY);
+        $formatter = new CurrencyFormatter($this->formatData, $this->data);
 
-        return $formatter->formatCurrency($value, $currency);
+        return $formatter->format($value, $currencyCode);
     }
 
     /**
@@ -77,11 +75,9 @@ class Currency extends Intl
      */
     public function formatAccounting($value, $currencyCode)
     {
-        $currency = $this->get($currencyCode);
-        $format = $this->formatData->get(null);
-        $formatter = new NumberFormatter($format, NumberFormatter::CURRENCY_ACCOUNTING);
+        $formatter = new CurrencyFormatter($this->formatData, $this->data);
 
-        return $formatter->formatCurrency($value, $currency);
+        return $formatter->format($value, $currencyCode, ['style' => 'accounting']);
     }
 
     /**
@@ -93,11 +89,9 @@ class Currency extends Intl
      */
     public function parse($value, $currencyCode)
     {
-        $currency = $this->get($currencyCode);
-        $format = $this->formatData->get(null);
-        $formatter = new NumberFormatter($format, NumberFormatter::CURRENCY);
+        $formatter = new CurrencyFormatter($this->formatData, $this->data);
 
-        return $formatter->parseCurrency($value, $currency);
+        return $formatter->parse($value, $currencyCode);
     }
 
     /**

--- a/src/IntlServiceProvider.php
+++ b/src/IntlServiceProvider.php
@@ -1,7 +1,7 @@
 <?php namespace Propaganistas\LaravelIntl;
 
 use Carbon\Carbon;
-use CommerceGuys\Intl\Country\CountryRepository;
+use CommerceGuys\Addressing\Country\CountryRepository;
 use CommerceGuys\Intl\Currency\CurrencyRepository;
 use CommerceGuys\Intl\Language\LanguageRepository;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
@@ -43,9 +43,7 @@ class IntlServiceProvider extends ServiceProvider
     protected function registerCountryRepository()
     {
         $this->app->singleton(CountryRepository::class, function ($app) {
-            $repository = new CountryRepository;
-            $repository->setDefaultLocale($app['config']['app.locale']);
-            $repository->setFallbackLocale($app['config']['app.fallback_locale']);
+            $repository = new CountryRepository($app['config']['app.locale'], $app['config']['app.fallback_locale']);
 
             return $repository;
         });
@@ -61,9 +59,7 @@ class IntlServiceProvider extends ServiceProvider
     protected function registerCurrencyRepository()
     {
         $this->app->singleton(CurrencyRepository::class, function ($app) {
-            $repository = new CurrencyRepository;
-            $repository->setDefaultLocale($app['config']['app.locale']);
-            $repository->setFallbackLocale($app['config']['app.fallback_locale']);
+            $repository = new CurrencyRepository($app['config']['app.locale'], $app['config']['app.fallback_locale']);
 
             return $repository;
         });
@@ -79,9 +75,7 @@ class IntlServiceProvider extends ServiceProvider
     protected function registerLanguageRepository()
     {
         $this->app->singleton(LanguageRepository::class, function ($app) {
-            $repository = new LanguageRepository;
-            $repository->setDefaultLocale($app['config']['app.locale']);
-            $repository->setFallbackLocale($app['config']['app.fallback_locale']);
+            $repository = new LanguageRepository($app['config']['app.locale'], $app['config']['app.fallback_locale']);
 
             return $repository;
         });
@@ -97,9 +91,7 @@ class IntlServiceProvider extends ServiceProvider
     protected function registerNumberRepository()
     {
         $this->app->singleton(NumberFormatRepository::class, function ($app) {
-            $repository = new NumberFormatRepository;
-            $repository->setDefaultLocale($app['config']['app.locale']);
-            $repository->setFallbackLocale($app['config']['app.fallback_locale']);
+            $repository = new NumberFormatRepository($app['config']['app.fallback_locale']);
 
             return $repository;
         });

--- a/src/Number.php
+++ b/src/Number.php
@@ -31,8 +31,7 @@ class Number extends Intl
      */
     public function format($value)
     {
-        $format = $this->get();
-        $formatter = new NumberFormatter($format);
+        $formatter = new NumberFormatter($this->data);
 
         return $formatter->format($value);
     }
@@ -45,10 +44,9 @@ class Number extends Intl
      */
     public function percent($value)
     {
-        $format = $this->get();
-        $formatter = new NumberFormatter($format, NumberFormatter::PERCENT);
+        $formatter = new NumberFormatter($this->data);
 
-        return $formatter->format($value);
+        return $formatter->format($value, ['style' => 'percent']);
     }
 
     /**
@@ -59,13 +57,9 @@ class Number extends Intl
      */
     public function parse($value)
     {
-        $format = $this->get(null);
-        $formatter = new NumberFormatter($format);
+        $formatter = new NumberFormatter($this->data);
 
-        // At time of writing, commerceguys/intl has number parsing still coupled to a currency. Parsing does
-        // succeed however,even though a value is provided without any currency. So let's just pass in
-        // a very rare currency to avoid unwanted formatting behavior. Sorry Cape Verdean Escudo!
-        return $formatter->parseCurrency($value, $currency = currency()->get('CVE'));
+        return $formatter->parse($value);
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ if (!function_exists('country')) {
      * Get a localized country name.
      *
      * @param string|null $countryCode
-     * @return \CommerceGuys\Intl\Country\Country|string
+     * @return \CommerceGuys\Addressing\Country\Country|string
      */
     function country($countryCode = null)
     {

--- a/tests/TestCountry.php
+++ b/tests/TestCountry.php
@@ -64,7 +64,7 @@ class TestCountry extends TestCase
     public function testGet()
     {
         $country = Country::get('BE');
-        $this->assertEquals('CommerceGuys\Intl\Country\Country', get_class($country));
+        $this->assertEquals('CommerceGuys\Addressing\Country\Country', get_class($country));
         $this->assertEquals('BE', $country->getCountryCode());
     }
 


### PR DESCRIPTION
Hi,

commerceguys/intl v1.0.0 is now out, and has breaking changes. Sorry about that.

I've had trouble understanding the full structure of your code, but I've made some initial fixes for you to use as a base:

1) Countries have moved to commerceguys/addressing, so I've added that library, and updated the references.

2) Repositories now take the default locale and fallback locale as constructor params, the methods have been removed. The locale can also be given to the individual methods. I've updated the service provider, but the individual facades will also need updating.

3) NumberFormatter has been split into NumberFormatter and CurrencyFormatter. I've updated the usage, but didn't know how to get the locale that needs to be passed along.

