### PR TITLE
Require illuminate/support instead of the full laravel framework.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "laravel/framework": ">=5.1,<5.7",
+        "illuminate/support": ">=5.1,<5.7",
         "commerceguys/intl": "^1.0.1",
         "jenssegers/date": "^3.2.3",
         "umpirsky/country-list": "^2.0",
@@ -25,8 +25,8 @@
         "punic/punic": "^3.1"
     },
     "require-dev": {
-        "orchestra/testbench": "*",
-        "phpunit/phpunit": "*"
+        "orchestra/testbench": ">=3.1",
+        "phpunit/phpunit": "^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
requiring laravel/framework was causing this package to pull in the entire laravel framework instead of just the libraries needed to work. This was causing errors when pulling this package into OctoberCMS which is based on laravel.

Set minimum version contstraints for dev packages so we don't pull in the oldest version of orchestra/testbench when running composer install.