### PR TITLE
Search Functionality

### DIFF
--- a/src/Contracts/Intl.php
+++ b/src/Contracts/Intl.php
@@ -5,6 +5,13 @@ namespace Propaganistas\LaravelIntl\Contracts;
 abstract class Intl
 {
     /**
+     * Store previously used keywords in memory.
+     * 
+     * @var array
+     */
+    protected static $searchCache = [];
+    
+    /**
      * Get the current locale.
      *
      * @return string
@@ -33,6 +40,93 @@ abstract class Intl
      * @return $this
      */
     abstract public function setFallbackLocale($locale);
+
+    /**
+     * Get the search cache.
+     * 
+     * @return array
+     */
+    public function getSearchCache()
+    {
+        return static::$searchCache;
+    }
+
+    /**
+     * Forget the search cache as whole or by key.
+     *
+     * @return array
+     */
+    public function forgetSearchCache($cacheKey = null)
+    {
+        if ($cacheKey) {
+            unset(static::$searchCache[$cacheKey]);
+        } else {
+            static::$searchCache = [];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Search the data by the given keywords.
+     * 
+     * @param  array|string $keywords
+     * @return array
+     */
+    public function search($keywords) {
+        [$keywords, $excludeKeywords, $includeKeywords] = $this->parseKeywords($keywords);
+
+        $cacheKey = md5(json_encode($keywords));
+
+        if (array_key_exists($cacheKey, static::$searchCache)) {
+            return static::$searchCache[$cacheKey];
+        }
+
+        $results = $this->all();
+
+        $filterCallback = function ($name) use ($includeKeywords, $excludeKeywords) {
+            $includeCondition = $excludeCondition = true;
+
+            if (! empty($includeKeywords)) {
+                $includeCondition = preg_match('/'.implode('|', $includeKeywords).'/', $name);
+            }
+
+            if (! empty($excludeKeywords)) {
+                $excludeCondition = !preg_match('/'.implode('|', $excludeKeywords).'/', $name);
+            }
+
+            return $includeCondition && $excludeCondition;
+        };
+
+        $results = array_filter($results, $filterCallback);
+
+        return static::$searchCache[$cacheKey] = $results;
+    }
+    
+    /**
+     * Parse the given keywords into include/exclude keywords.
+     *
+     * @param  array|string $keywords
+     * @return array
+     */
+    protected function parseKeywords($keywords)
+    {
+        if (is_string($keywords)) {
+            $keywords = explode('|', $keywords);
+        }
+
+        $excludeKeywords = $includeKeywords = [];
+
+        foreach ($keywords as $keyword) {
+            if (Str::startsWith($keyword, ['-', '\\-'])) {
+                $excludeKeywords[] = str_replace(['-', '\\'], '', $keyword);
+            }  else {
+                $includeKeywords[] = $keyword;
+            }
+        }
+
+        return [$keywords, $excludeKeywords, $includeKeywords];
+    }
 
     /**
      * Run the given callable while using another locale.

--- a/src/Contracts/Intl.php
+++ b/src/Contracts/Intl.php
@@ -88,11 +88,11 @@ abstract class Intl
             $includeCondition = $excludeCondition = true;
 
             if (! empty($includeKeywords)) {
-                $includeCondition = preg_match('/'.implode('|', $includeKeywords).'/', $name);
+                $includeCondition = (bool) preg_match('/'.implode('|', $includeKeywords).'/', $name);
             }
 
             if (! empty($excludeKeywords)) {
-                $excludeCondition = !preg_match('/'.implode('|', $excludeKeywords).'/', $name);
+                $excludeCondition = ! (bool) preg_match('/'.implode('|', $excludeKeywords).'/', $name);
             }
 
             return $includeCondition && $excludeCondition;


### PR DESCRIPTION
Simple search functionality, extremely useful.

Splits the keywords via `|` and excludes the keywords starting with `-`.

```php
$results = country()->search('-alm|anya');
```

The code above will include any country which contains `anya` and from those filters the ones who contains `-alm`